### PR TITLE
Add ability to change value with `value` prop to prevent wrong internal value.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "chai": "^3.4.1",
     "classnames": "^2.2.3",
     "css-loader": "^0.23.1",
+    "enzyme": "^2.3.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.35.0",
     "eslint": "^2.10.2",

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -22,7 +22,8 @@ export const MaskedInput = React.createClass({
     if (
       nextProps.mask !== this.props.mask ||
       nextProps.guide !== this.props.guide ||
-      nextProps.placeholderCharacter !== this.props.placeholderCharacter
+      nextProps.placeholderCharacter !== this.props.placeholderCharacter ||
+      (nextProps.value !== undefined && nextProps.value !== this.state.conformedInput)
     ) {
       const {mask, value: inputValue, guide, placeholderCharacter: placeholderChar} = nextProps
 

--- a/react/src/reactTextMask.jsx
+++ b/react/src/reactTextMask.jsx
@@ -23,7 +23,8 @@ export const MaskedInput = React.createClass({
       nextProps.mask !== this.props.mask ||
       nextProps.guide !== this.props.guide ||
       nextProps.placeholderCharacter !== this.props.placeholderCharacter ||
-      (nextProps.value !== undefined && nextProps.value !== this.state.conformedInput)
+      nextProps.value !== undefined && nextProps.value !== this.state.conformedInput ||
+      this.props.value !== undefined && nextProps.value === undefined
     ) {
       const {mask, value: inputValue, guide, placeholderCharacter: placeholderChar} = nextProps
 

--- a/react/test/reactTextMask.spec.jsx
+++ b/react/test/reactTextMask.spec.jsx
@@ -5,6 +5,7 @@ import React from 'react' // eslint-disable-line
 import sinon from 'sinon'
 import _ from 'lodash'
 import ReactTestUtils from 'react-addons-test-utils'
+import {mount} from 'enzyme'
 import dynamicTests from 'mocha-dynamic-tests'
 import testParameters, {
   noGuideMode,
@@ -63,6 +64,69 @@ describe('MaskedInput', () => {
       expect(userOnChange.called).to.equal(true)
     })
 
+    it('changes internal value if controlled external value is different than current', () => {
+      const userOnChange = sinon.spy()
+
+      const maskedInput = mount(
+        <MaskedInput mask='111-111' value='222-222' onChange={userOnChange} guide={true}/>
+      )
+
+      let input = maskedInput.find('input').get(0)
+
+      expect(input.value).to.equal('222-222')
+
+      maskedInput.setProps({value: '333-333'})
+
+      input = maskedInput.find('input').get(0)
+
+      expect(input.value).to.equal('333-333')
+    })
+
+    it('changes internal value if starts uncontrolled and becomes controlled', () => {
+      const userOnChange = sinon.spy()
+
+      const maskedInput = mount(
+        <MaskedInput mask='111-111' onChange={userOnChange} guide={true}/>
+      )
+
+      let inputWrapper = maskedInput.find('input')
+      let input = inputWrapper.get(0)
+
+      input.value = '222-222'
+      inputWrapper.simulate('focus')
+      inputWrapper.simulate('change')
+
+      expect(userOnChange.called).to.equal(true)
+
+      expect(input.value).to.equal('222-222')
+
+      maskedInput.setProps({value: '333-333'})
+
+      expect(input.value).to.equal('333-333')
+    })
+
+    it('preserves internal value if controlled then becomes uncontrolled', () => {
+      const userOnChange = sinon.spy()
+
+      const maskedInput = mount(
+        <MaskedInput mask='111-111' value='222-222' onChange={userOnChange} guide={true}/>
+      )
+
+      let inputWrapper = maskedInput.find('input')
+      let input = inputWrapper.get(0)
+
+      input.value = '222-222'
+      inputWrapper.simulate('focus')
+      inputWrapper.simulate('change')
+
+      expect(userOnChange.called).to.equal(true)
+
+      expect(input.value).to.equal('222-222')
+
+      maskedInput.setProps({value: undefined})
+
+      expect(input.value).to.equal('222-222')
+    })
     it('calls user provided `onChange` with correct event value', () => {
       const userOnChange = sinon.spy()
       const maskedInput = ReactTestUtils.renderIntoDocument(

--- a/react/test/reactTextMask.spec.jsx
+++ b/react/test/reactTextMask.spec.jsx
@@ -105,7 +105,7 @@ describe('MaskedInput', () => {
       expect(input.value).to.equal('333-333')
     })
 
-    it('preserves internal value if controlled then becomes uncontrolled', () => {
+    it('destroys internal value if controlled then becomes uncontrolled', () => {
       const userOnChange = sinon.spy()
 
       const maskedInput = mount(
@@ -115,17 +115,28 @@ describe('MaskedInput', () => {
       let inputWrapper = maskedInput.find('input')
       let input = inputWrapper.get(0)
 
-      input.value = '222-222'
-      inputWrapper.simulate('focus')
-      inputWrapper.simulate('change')
-
-      expect(userOnChange.called).to.equal(true)
-
       expect(input.value).to.equal('222-222')
 
       maskedInput.setProps({value: undefined})
 
+      expect(input.value).to.equal('')
+    })
+
+    it('destroys internal value if controlled then becomes an empty string value', () => {
+      const userOnChange = sinon.spy()
+
+      const maskedInput = mount(
+        <MaskedInput mask='111-111' value='222-222' onChange={userOnChange} guide={true}/>
+      )
+
+      let inputWrapper = maskedInput.find('input')
+      let input = inputWrapper.get(0)
+
       expect(input.value).to.equal('222-222')
+
+      maskedInput.setProps({value: ''})
+
+      expect(input.value).to.equal('')
     })
     it('calls user provided `onChange` with correct event value', () => {
       const userOnChange = sinon.spy()


### PR DESCRIPTION
Compares the next value to the current value on state. If they are different than it'll trigger a change in state.
Should handle:
Controlled => Controlled (always having a value externally)
Uncontrolled => Controlled (no value to start, then changing value)

However unsure about this one:
Controlled => Uncontrolled ( start with value, then value is undefined)

I have it so that it destroys the value. Since you went from value => no value I assumed that's how it should work.