### PR TITLE
fixing typing errors.

### DIFF
--- a/angular2/dist/angular2TextMask.d.ts
+++ b/angular2/dist/angular2TextMask.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../typings/index.d.ts" />
 import { ElementRef } from '@angular/core';
 import { NgControl } from '@angular/common';
 export default class MaskedInputDirective {


### PR DESCRIPTION
referencing `/// <reference path="../typings/index.d.ts" />`  cause some typing errors.